### PR TITLE
Added nix build environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 /.cabal-sandbox
 /cabal.sandbox.config
+result*

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,68 @@
+NPROCS ?= 1
+OS := $(shell uname -s)
+
+ifeq ($(OS),Linux)
+  NPROCS := $(shell nproc)
+endif
+ifeq ($(OS),Darwin)
+  NPROCS := $(shell sysctl -n hw.ncpu)
+endif
+ifeq ($(OS),FreeBSD)
+  NPROCS := $(shell sysctl -n hw.ncpu)
+endif
+
+# This should ideally be updated from the nixos-17.09 branch of the repository
+# at https://github.com/NixOS/nixpkgs-channels
+NIXPKGS_REVISION = 788ce6e3df12bb0cf19fb9ccf8ffa75558b551ba
+
+.PHONY: all help configure build       \
+        lib-repl exe-repl test-repl    \
+        nix-build nix-shell update-nix
+
+all: help
+
+help:
+	-@echo "Targets:"
+	-@echo "  configure:  cabal configure"
+	-@echo "  build:      cabal build"
+	-@echo "  lib-repl:   cabal repl lib:capnp"
+	-@echo "  exe-repl:   cabal repl exe:capnpc-haskell"
+	-@echo "  test-repl:  cabal repl test:the-test-suite"
+	-@echo "  nix-build:  build via nix"
+	-@echo "  nix-shell:  open a nix shell"
+	-@echo "  update-nix: update any pinned nix files"
+
+configure:
+	cabal configure --enable-tests
+
+build: configure
+	cabal build -j
+
+lib-repl: configure
+	cabal repl "lib:capnp"
+
+exe-repl: configure
+	cabal repl "exe:capnpc-haskell"
+
+test-repl: configure
+	cabal repl "test:the-test-suite"
+
+nix-build: nix/capnp.nix
+	-@rm -f result*
+	nix-build --no-out-link release.nix -A capnp -Q -j $(NPROCS)
+
+# I've seen problems caused by not running cabal clean before entering a
+# nix shell. In particular, I think the result of cabal configure can be
+# inappropriately cached from executions in a different environment.
+nix-shell: nix/capnp.nix
+	cabal clean
+	nix-shell --run $$SHELL
+
+# another example of something that would go under this rule:
+# cd nix; cabal2nix "https://github.com/zenhack/haskell-quota" > quota.nix
+update-nix: nix/capnp.nix
+	nix-prefetch-git "https://github.com/NixOS/nixpkgs" $(NIXPKGS_REVISION) \
+	    > nix/nixpkgs.json
+
+nix/capnp.nix: capnp.cabal
+	cd nix; cabal2nix ../. > capnp.nix

--- a/nix/capnp.nix
+++ b/nix/capnp.nix
@@ -1,0 +1,30 @@
+{ mkDerivation, array, base, binary, bytes, bytestring, cereal
+, deepseq, directory, exceptions, heredoc, HUnit, mtl, primitive
+, process, QuickCheck, quota, reinterpret-cast, resourcet, stdenv
+, template-haskell, test-framework, test-framework-hunit
+, test-framework-quickcheck2, text, transformers, vector
+}:
+mkDerivation {
+  pname = "capnp";
+  version = "0.1.0.0";
+  src = ../.;
+  isLibrary = true;
+  isExecutable = true;
+  libraryHaskellDepends = [
+    array base bytes bytestring exceptions mtl primitive quota
+    template-haskell text transformers vector
+  ];
+  executableHaskellDepends = [
+    array base binary bytes bytestring cereal exceptions mtl primitive
+    quota transformers vector
+  ];
+  testHaskellDepends = [
+    base binary bytestring deepseq directory exceptions heredoc HUnit
+    mtl primitive process QuickCheck quota reinterpret-cast resourcet
+    template-haskell test-framework test-framework-hunit
+    test-framework-quickcheck2 transformers vector
+  ];
+  homepage = "https://github.com/zenhack/haskell-capnp";
+  description = "Cap'n Proto for Haskell";
+  license = stdenv.lib.licenses.mit;
+}

--- a/nix/nixpkgs.json
+++ b/nix/nixpkgs.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/NixOS/nixpkgs",
+  "rev": "788ce6e3df12bb0cf19fb9ccf8ffa75558b551ba",
+  "date": "2017-06-02T21:28:33+01:00",
+  "sha256": "0b076a7clxapyl54l50njwajnsc2v886240g434g6c9q2f768qq5",
+  "fetchSubmodules": true
+}

--- a/nix/nixpkgs.nix
+++ b/nix/nixpkgs.nix
@@ -1,0 +1,53 @@
+# In order to update `nixpkgs.json` to a specific revision, run:
+#
+# ```bash
+# $ nix-prefetch-git https://github.com/NixOS/nixpkgs.git "${REVISION}" > nixpkgs.json
+# ```
+
+with rec {
+  system = builtins.currentSystem;
+
+  builtin-paths = import <nix/config.nix>;
+
+  nixpkgs-json = builtins.fromJSON (builtins.readFile ./nixpkgs.json);
+
+  # The nixpkgs to use when bootstrapping. This shouldn't matter except insofar
+  # as it needs to have fetchFromGitHub and ideally the binary cache should be
+  # populated for this.
+  hashes = {
+    commit = "76d649b59484607901f0c1b8f737d8376a904019";
+    sha = "04xp12gmjby84k4pabc0nspggf4pgycnl764zf7w50izx65r9q8x";
+  };
+
+  stage1-tarball = import <nix/fetchurl.nix> {
+    url = "https://github.com/NixOS/nixpkgs/archive/${hashes.commit}.tar.gz";
+    sha256 = hashes.sha;
+  };
+
+  stage1-path = builtins.derivation {
+    name = "nixpkgs-bootstrap-stage1";
+    builder = builtin-paths.shell;
+    args = [
+      (builtins.toFile "nixpkgs-unpacker" ''
+        "$coreutils/mkdir" -p "$out"
+        cd "$out"
+        "$gzip" -c -d "$tarball" > temporary.tar
+        "$tar" -xf temporary.tar --strip-components=1
+        "$coreutils/rm" temporary.tar
+      '')
+    ];
+
+    inherit system;
+
+    inherit (builtin-paths) tar gzip coreutils;
+    tarball = stage1-tarball;
+  };
+
+  stage1 = import stage1-path { inherit system; };
+};
+
+stage1.fetchFromGitHub {
+  owner = "NixOS";
+  repo  = "nixpkgs";
+  inherit (nixpkgs-json) rev sha256;
+}

--- a/release.nix
+++ b/release.nix
@@ -1,0 +1,55 @@
+{ nixpkgs ? import ./nix/nixpkgs.nix, compiler ? "default" }:
+
+with rec {
+  pkgs = import nixpkgs {};
+
+  inherit (pkgs) lib;
+
+  haskellPackagesNormal = (
+    if compiler == "default"
+    then pkgs.haskellPackages
+    else pkgs.haskell.packages.${compiler});
+
+  sources = {
+    quota = pkgs.fetchFromGitHub {
+      repo   = "haskell-quota";
+      owner  = "zenhack";
+      rev    = "3059085facf116857313a88ffc0debefbf86aafa";
+      sha256 = "1xaj4vfa67m674z1h18g7jafpp36c10jjf3jcwvdr0b2a0p6i06c";
+    };
+  };
+
+  withFilteredSource = pkg: pkg.overrideDerivation (old:
+    with {
+      sf = name: type: let bn = baseNameOf (toString name); in !(
+        (type == "directory" && (bn == ".git"))
+        || pkgs.lib.hasSuffix "~" bn
+        || pkgs.lib.hasSuffix ".o" bn
+        || pkgs.lib.hasSuffix ".so" bn
+        || pkgs.lib.hasSuffix ".nix" bn
+        || (type == "symlink" && pkgs.lib.hasPrefix "result" bn)
+      );
+    };
+    { src = builtins.filterSource sf ./.; });
+
+  haskellPackages = (
+    haskellPackagesNormal.override {
+      overrides = self: super: (
+        with {
+          # lots of functions in pkgs.haskell.lib are annoyingly flipped
+          addBuildTool = pkgs.lib.flip pkgs.haskell.lib.addBuildTool;
+        };
+
+        {
+          quota = self.callCabal2nix "quota" sources.quota {};
+          capnp = (
+            withFilteredSource
+            (addBuildTool pkgs.capnproto
+            (self.callPackage ./nix/capnp.nix {})));
+        });
+    });
+};
+
+{
+  capnp = haskellPackages.capnp;
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,4 @@
+{ nixpkgs ? import ./nix/nixpkgs.nix, compiler ? "default", pkgName ? "capnp" }:
+
+let drv = (import ./release.nix { inherit nixpkgs compiler; }).${pkgName};
+in if builtins.getEnv "IN_NIX_SHELL" != "" then drv.env else drv


### PR DESCRIPTION
Now you can `nix-build shell.nix` and it will successfully build if you have Nix installed and your nixpkgs git revision is the same as mine :-)

I'll make another PR with [portable bootstrapping of a pinned nixpkgs](https://gist.github.com/taktoa/4ec8b0cb6d07857400b07a830ad99558) later.