### PR TITLE
Added declarative Hydra jobset specification

### DIFF
--- a/nix/declarative.nix
+++ b/nix/declarative.nix
@@ -1,0 +1,79 @@
+{ nixpkgs, prsJSON }:
+
+with { pkgs = import nixpkgs {}; };
+
+with {
+  mkJobset = (
+    { enabled          ? 1,
+      hidden           ? false,
+      description      ? "",
+      checkinterval    ? 30,
+      schedulingshares ? 10,
+      enableemail      ? false,
+      emailoverride    ? false,
+      keepnr           ? 3,
+      nixexprinput,
+      nixexprpath,
+      inputs
+    }@args:
+
+    {
+      inherit enabled hidden description;
+      inherit emailoverride enableemail;
+      inherit checkinterval schedulingshares keepnr;
+      inherit nixexprinput nixexprpath inputs;
+    } // args);
+
+  mkFetchGithub = value: {
+    inherit value;
+    type = "git";
+    emailresponsible = false;
+  };
+};
+
+with pkgs.lib;
+
+with rec {
+  mkProjectJobset = (
+    { url ? null, branch ? "master", ... }@args:
+
+    mkJobset ((removeAttrs args ["url" "branch"]) // {
+      nixexprpath = "release.nix";
+      nixexprinput = "src";
+      inputs = {
+        src = mkFetchGithub (
+          if url != null
+          then "${url} ${branch}"
+          else "https://github.com/zenhack/haskell-capnp ${branch}");
+      };
+    }));
+
+  primaryJobsets = {
+    "zenhack-master" = mkProjectJobset {
+      branch = "master";
+      description = "zenhack/haskell-capnp master";
+    };
+  };
+
+  prData = builtins.fromJSON (builtins.readFile prsJSON);
+
+  makePr = num: info: (
+    with { inherit (info.head) repo; };
+    {
+      name = "zenhack-master-pr-${num}";
+      value = mkProjectJobset {
+        description = "PR ${num}: ${info.title}";
+        url = "https://github.com/${repo.owner.login}/${repo.name}.git";
+        branch = info.head.ref;
+      };
+    });
+
+  pullRequests = listToAttrs (mapAttrsToList makePr prData);
+
+  jobsetsAttrs = pullRequests // primaryJobsets;
+};
+
+{
+  jobsets = pkgs.writeText "spec.json" (builtins.toJSON jobsetsAttrs);
+}
+

--- a/nix/spec.json
+++ b/nix/spec.json
@@ -1,0 +1,17 @@
+{
+    "enabled": 1,
+    "hidden": false,
+    "description": "Jobsets",
+    "nixexprinput": "src",
+    "nixexprpath": "nix/declarative.nix",
+    "checkinterval": 15,
+    "schedulingshares": 10,
+    "enableemail": true,
+    "emailoverride": "",
+    "keepnr": 10,
+    "inputs": {
+         "src": { "type": "git", "value": "https://github.com/zenhack/haskell-capnp.git master", "emailresponsible": false },
+         "nixpkgs": { "type": "git", "value": "https://github.com/NixOS/nixpkgs-channels.git nixos-17.09", "emailresponsible": false },
+         "prsJSON": { "type": "githubpulls", "value": "zenhack haskell-capnp", "emailresponsible": false }
+     }
+}


### PR DESCRIPTION
This simultaneously moves the code in [this gist](https://gist.github.com/taktoa/c44d040f05e0b7739f3902e6eb0b77fb) into proper version control and tests it (can't test PR building without at least one open PR :P)

Once this is merged, I can switch the [project](https://hydra.angeldsis.com/project/haskell-capnp) over from the gist.

If you want to get a GitHub build status on each PR, then I'll need a GitHub auth token for an account with push access on this repo (e.g.: yours). It only needs to have the `repo:status` permission, so it's relatively harmless, though if you're ultraparanoid you can make a separate GitHub account that only has push access to this repo and give me a token from that account.