### PR TITLE
Allocate new segments instead of growing them.

### DIFF
--- a/tests/Module/Capnp/Untyped.hs
+++ b/tests/Module/Capnp/Untyped.hs
@@ -296,7 +296,7 @@ farPtrTest = describe "Setting cross-segment pointers shouldn't crash" $ do
         evalLimitT maxBound $ do
             msg <- M.newMessage
             srcStruct <- allocStruct msg 4 4
-            (1, _) <- M.newSegment msg 10
+            (_, _) <- M.newSegment msg 10
             dstStruct <- allocStruct msg 2 2
             ptr <- C.toPtr msg dstStruct
             setPtr ptr 0 srcStruct


### PR DESCRIPTION
This changes `alloc` so that it allocates a new segment when the last one runs out of space, like [MallocMessageBuilder](https://github.com/capnproto/capnproto/blob/master/c%2B%2B/src/capnp/message.h#L359) in the C++ runtime. This saves unnecessary copies when growing and also allows messages larger than 2GB (which was my original problem).