### PR TITLE
Fix #74

### DIFF
--- a/lib/Capnp/Rpc/Untyped.hs
+++ b/lib/Capnp/Rpc/Untyped.hs
@@ -815,14 +815,16 @@ call info@Server.CallInfo { response } (Client (Just client')) = liftSTM $ do
                 RemoteDest AnswerDest { conn, answer } ->
                     callRemote conn info $ AnswerTgt answer
 
-                RemoteDest (ImportDest (Fin.get -> ImportRef { conn, importId })) ->
+                RemoteDest (ImportDest cell) -> do
+                    ImportRef { conn, importId } <- Fin.get cell
                     callRemote conn info (ImportTgt importId)
 
             Error exn -> do
                 breakPromise response' exn
                 pure localPipeline
 
-        ImportClient (Fin.get -> ImportRef { conn, importId }) ->
+        ImportClient cell -> do
+            ImportRef { conn, importId } <- Fin.get cell
             callRemote conn info (ImportTgt importId)
 
 makeLocalPipeline :: Fulfiller RawMPtr -> STM (Pipeline, Fulfiller RawMPtr)
@@ -1034,7 +1036,7 @@ export sup ops = liftSTM $ do
             , unwrapper = Server.handleCast ops
             }
     superviseSTM sup $ do
-        Fin.addFinalizer finalizerKey $ atomically $ Rc.release qCall
+        Fin.addFinalizer finalizerKey $ Rc.release qCall
         Server.runServer q ops
     pure $ Client (Just client')
 
@@ -1440,13 +1442,20 @@ handleDisembargoMsg conn d = getLive conn >>= go d
         disembargoPromise _ =
             abortDisembargo "targets something that is not a promise."
 
-        disembargoClient (ImportClient (Fin.get -> ImportRef {conn=targetConn, importId}))
-            | conn == targetConn =
-                sendPureMsg conn' $ R.Message'disembargo R.Disembargo
-                    { context = R.Disembargo'context'receiverLoopback embargoId
-                    , target = R.MessageTarget'importedCap (ieWord importId)
-                    }
-        disembargoClient _ =
+        disembargoClient (ImportClient cell) = do
+            client <- Fin.get cell
+            case client of
+                ImportRef {conn=targetConn, importId}
+                    | conn == targetConn ->
+                        sendPureMsg conn' $ R.Message'disembargo R.Disembargo
+                            { context = R.Disembargo'context'receiverLoopback embargoId
+                            , target = R.MessageTarget'importedCap (ieWord importId)
+                            }
+                _ ->
+                    abortDisembargoClient
+        disembargoClient _ = abortDisembargoClient
+
+        abortDisembargoClient =
                 abortDisembargo $
                     "targets a promise which has not resolved to a capability"
                     <> " hosted by the sender."
@@ -1751,6 +1760,10 @@ resolveClientClient tmpDest resolve (Client client) =
             -- clarification on the mailing list.
             disembargoAndResolve dest
 
+        -- Local promises never need embargos; we can just forward:
+        ( _, LocalDest LocalBuffer { callBuffer } ) ->
+            flushAndResolve callBuffer
+
         -- These cases are slightly subtle; despite resolving to a
         -- client that points at a "remote" target, if it points into a
         -- _different_ connection, we must be proxying it, so we treat
@@ -1760,25 +1773,27 @@ resolveClientClient tmpDest resolve (Client client) =
         --
         -- If it's pointing into the same connection, we don't need to
         -- do a disembargo.
-        ( Just PromiseClient { origTarget=RemoteDest newDest }, RemoteDest oldDest )
-            | destConn newDest /= destConn oldDest ->
-                disembargoAndResolve oldDest
-            | otherwise ->
-                releaseAndResolve
-        ( Just (ImportClient (Fin.get -> ImportRef { conn=newConn })), RemoteDest oldDest )
-            | newConn /= destConn oldDest ->
-                disembargoAndResolve oldDest
-            | otherwise ->
-                releaseAndResolve
-
-        -- Local promises never need embargos; we can just forward:
-        ( _, LocalDest LocalBuffer { callBuffer } ) ->
-            flushAndResolve callBuffer
+        ( Just PromiseClient { origTarget=RemoteDest newDest }, RemoteDest oldDest ) -> do
+            newConn <- destConn newDest
+            oldConn <- destConn oldDest
+            if newConn == oldConn
+                then releaseAndResolve
+                else disembargoAndResolve oldDest
+        ( Just (ImportClient cell), RemoteDest oldDest ) -> do
+            ImportRef { conn=newConn } <- Fin.get cell
+            oldConn <- destConn oldDest
+            if newConn == oldConn
+                then releaseAndResolve
+                else disembargoAndResolve oldDest
   where
-    destConn AnswerDest { conn }                          = conn
-    destConn (ImportDest (Fin.get -> ImportRef { conn })) = conn
-    destTarget AnswerDest { answer } = AnswerTgt answer
-    destTarget (ImportDest (Fin.get -> ImportRef { importId })) = ImportTgt importId
+    destConn AnswerDest { conn } = pure conn
+    destConn (ImportDest cell) = do
+        ImportRef { conn } <- Fin.get cell
+        pure conn
+    destTarget AnswerDest { answer } = pure $ AnswerTgt answer
+    destTarget (ImportDest cell) = do
+        ImportRef { importId } <- Fin.get cell
+        pure $ ImportTgt importId
 
     releaseAndResolve = do
         releaseTmpDest tmpDest
@@ -1792,11 +1807,13 @@ resolveClientClient tmpDest resolve (Client client) =
     flushAndRaise callBuffer e =
         flushTQueue callBuffer >>=
             traverse_ (\Server.CallInfo{response} -> breakPromise response e)
-    disembargoAndResolve dest@(destConn -> Conn{liveState}) =
+    disembargoAndResolve dest = do
+        Conn{liveState} <- destConn dest
         readTVar liveState >>= \case
             Live conn' -> do
                 callBuffer <- newTQueue
-                disembargo conn' (destTarget dest) $ \case
+                target <- destTarget dest
+                disembargo conn' target $ \case
                     Right () ->
                         flushAndResolve callBuffer
                     Left e ->
@@ -1878,7 +1895,7 @@ resolveClientReturn tmpDest resolve conn@Conn'{answers} transform R.Return { uni
 -- bump the refcount.
 getConnExport :: Conn -> Client' -> STM IEId
 getConnExport conn client = getLive conn >>= \conn'@Conn'{exports} -> do
-    let ExportMap m = clientExportMap client
+    ExportMap m <- clientExportMap client
     val <- M.lookup conn m
     case val of
         Just eid -> do
@@ -1896,7 +1913,7 @@ getConnExport conn client = getLive conn >>= \conn'@Conn'{exports} -> do
 -- freeing the export id, and dropping the client's refcount.
 dropConnExport :: Conn -> Client' -> STM ()
 dropConnExport conn client' = do
-    let ExportMap eMap = clientExportMap client'
+    ExportMap eMap <- clientExportMap client'
     val <- M.lookup conn eMap
     case val of
         Just eid -> do
@@ -1907,10 +1924,12 @@ dropConnExport conn client' = do
         Nothing ->
             error "BUG: tried to drop an export that doesn't exist."
 
-clientExportMap :: Client' -> ExportMap
-clientExportMap LocalClient{exportMap}                         = exportMap
-clientExportMap PromiseClient{exportMap}                       = exportMap
-clientExportMap (ImportClient (Fin.get -> ImportRef{proxies})) = proxies
+clientExportMap :: Client' -> STM ExportMap
+clientExportMap LocalClient{exportMap}   = pure exportMap
+clientExportMap PromiseClient{exportMap} = pure exportMap
+clientExportMap (ImportClient cell) = do
+    ImportRef{proxies} <- Fin.get cell
+    pure proxies
 
 -- | insert the client into the exports table, bumping the refcount if it is
 -- already there. If a different client is already in the table at the same
@@ -1941,16 +1960,20 @@ emitCap targetConn (Client (Just client')) = case client' of
         Pending { tmpDest = RemoteDest AnswerDest { conn, answer } }
             | conn == targetConn ->
                 pure $ R.CapDescriptor'receiverAnswer (marshalPromisedAnswer answer)
-        Pending { tmpDest = RemoteDest (ImportDest (Fin.get -> ImportRef { conn, importId = IEId iid })) }
-            | conn == targetConn ->
-                pure $ R.CapDescriptor'receiverHosted iid
+        Pending { tmpDest = RemoteDest (ImportDest cell) } -> do
+            ImportRef { conn, importId = IEId iid } <- Fin.get cell
+            if conn == targetConn
+                then pure (R.CapDescriptor'receiverHosted iid)
+                else newSenderPromise
         _ ->
-            R.CapDescriptor'senderPromise . ieWord <$> getConnExport targetConn client'
-    ImportClient (Fin.get -> ImportRef { conn=hostConn, importId })
-        | hostConn == targetConn ->
-            pure (R.CapDescriptor'receiverHosted (ieWord importId))
-        | otherwise ->
-            R.CapDescriptor'senderHosted . ieWord <$> getConnExport targetConn client'
+            newSenderPromise
+    ImportClient cell -> do
+        ImportRef { conn=hostConn, importId } <- Fin.get cell
+        if hostConn == targetConn
+            then pure (R.CapDescriptor'receiverHosted (ieWord importId))
+            else R.CapDescriptor'senderHosted . ieWord <$> getConnExport targetConn client'
+  where
+    newSenderPromise = R.CapDescriptor'senderPromise . ieWord <$> getConnExport targetConn client'
 
 -- | 'acceptCap' is a dual of 'emitCap'; it derives a Client from a CapDescriptor
 -- received via the connection. May update connection state as necessary.
@@ -1974,7 +1997,7 @@ acceptCap conn cap = getLive conn >>= \conn' -> go conn' cap
                     , importId
                     , proxies
                     }
-                queueIO conn' $ Fin.addFinalizer cell $ atomically (Rc.decr localRc)
+                queueIO conn' $ Fin.addFinalizer cell $ Rc.decr localRc
                 pure $ Client $ Just $ ImportClient cell
 
             Nothing ->
@@ -1995,7 +2018,8 @@ acceptCap conn cap = getLive conn >>= \conn' -> go conn' cap
                     , origTarget
                     }
             Nothing -> do
-                rec imp@(Fin.get -> ImportRef{proxies}) <- newImport importId conn (Just (pState, tmpDest))
+                rec imp <- newImport importId conn (Just (pState, tmpDest))
+                    ImportRef{proxies} <- Fin.get imp
                     let tmpDest = RemoteDest (ImportDest imp)
                     pState <- newTVar Pending { tmpDest }
                 pure $ Client $ Just PromiseClient
@@ -2042,7 +2066,7 @@ newImport importId conn promiseState = getLive conn >>= \conn'@Conn'{imports} ->
         importId
         imports
     cell <- Fin.newCell importRef
-    queueIO conn' $ Fin.addFinalizer cell $ atomically (Rc.decr localRc)
+    queueIO conn' $ Fin.addFinalizer cell $ Rc.decr localRc
     pure cell
 
 -- | Release the identified import. Removes it from the table and sends a release

--- a/lib/Internal/Finalizer.hs
+++ b/lib/Internal/Finalizer.hs
@@ -23,9 +23,11 @@ From the docs for the 'Weak' type:
 So instead, we provide a 'Cell' type, which:
 
 * Wraps simple value
-* Can be created inside STM, and
+* Can be created and read inside STM, and
 * May safely have finalizers, using the 'addFinalizer' function in
   this module.
+* Ensures that the finalizers will not be run before any transaction that
+  reads data is complete.
 
 Note that it is *not* safe to use the primitives from "Sys.Mem.Weak" to
 add finalizers.
@@ -36,80 +38,41 @@ module Internal.Finalizer (Cell, get, newCell, addFinalizer) where
 
 import Control.Concurrent.MVar (MVar, mkWeakMVar, newEmptyMVar)
 import Control.Concurrent.STM
-    ( STM
-    , TVar
-    , atomically
-    , modifyTVar'
-    , newTVar
-    , readTVar
-    , readTVarIO
-    , retry
-    , writeTVar
-    )
-import Control.Monad           (when)
-import GHC.Conc                (unsafeIOToSTM)
+    (STM, TVar, atomically, modifyTVar', newTVar, readTVar)
 
 -- | A cell, containing a value and possibly finalizers.
-newtype Cell a = Cell (TVar (CellState a))
+newtype Cell a
+    = Cell (TVar (CellData a))
     deriving(Eq)
 
-data CellState a = CellState
-    { value       :: a
+-- The actual contents of a cell. This is wrapped in a 'TVar' to force accesses
+-- to add the a reference the transaction log from which the finalizers are
+-- reachable, thus preventing them from running before the completion of any
+-- transaction that examines the value.
+data CellData a = CellData
+    { value      :: a
     -- ^ The value wrapped by the cell.
-    , finalizers  :: TVar [MVar ()]
+
+    , finalizers :: [MVar ()]
     -- ^ Experimentally, TVars appear not to be safe for finalizers, so
     -- instead we create MVars for the finalizers, and store them this
     -- list so that we maintain a reference to them.
-
-    , isFinalized :: TVar Bool
-    -- ^ Note [Finalizer race]
     }
     deriving(Eq)
 
 -- | Get the value from a cell
 get :: Cell a -> STM a
-get (Cell state) = do
-    CellState{value, isFinalized} <- readTVar state
-    finalized <- readTVar isFinalized
-    when finalized $ do
-        -- Note [Finalizer race]
-        unsafeIOToSTM $ putStrLn "BUG in haskell-capnp: finalizer ran before Cell was unreachable!"
-        retry
-    pure value
+get (Cell state) = value <$> readTVar state
 
 -- Create  a new cell, initially with no finalizers.
 newCell :: a -> STM (Cell a)
-newCell value = do
-    isFinalized <- newTVar False
-    finalizers <- newTVar []
-    Cell <$> newTVar CellState { value, finalizers, isFinalized }
+newCell value = Cell <$> newTVar CellData { value, finalizers = [] }
 
 -- Add a new finalizer to the cell. Cells may have many finalizers
 -- attached.
 addFinalizer :: Cell a -> STM () -> IO ()
-addFinalizer (Cell state) fin = do
-    CellState {finalizers, isFinalized} <- readTVarIO state
+addFinalizer (Cell stateVar) fin = do
     mvar <- newEmptyMVar
-    _ <- mkWeakMVar mvar $ atomically $ do
-        fin
-        writeTVar isFinalized True
-    atomically $ modifyTVar' finalizers (mvar:)
-
--- Note [Finalizer race]
---
--- Per issue #74, in a previous implementation it was possible for the cell to
--- be collected before a transaction that used it completes, and for the finalizer
--- to run to completion also before the transaction completes. To avoid this,
--- we need to make sure that the finalizer and any transaction that uses the cell
--- conflict, such that the finalizer always comes in a *later* transaction.
---
--- To achieve this we store a shared isFinalized TVar, and write to it from the
--- finalizers. 'get' reads it and verifies that it has not been set; if it has
--- it retries.
---
--- Subtly, this actually prevents the finalizer from running, because the
--- possibility of a retry means we need to keep holding the reference so we
--- can access the cell in a subsequent attempt -- so the retry should never actually
--- occur, but still needs to be there for correctness. We add a print statement
--- to the branch, so that if there is a bug where this actually *can* happen,
--- we get some indicator of this, rather than just deadlocking.
+    _ <- mkWeakMVar mvar $ atomically fin
+    atomically $ modifyTVar' stateVar $ \state@CellData{finalizers} ->
+        state { finalizers = mvar : finalizers }

--- a/lib/Internal/Finalizer.hs
+++ b/lib/Internal/Finalizer.hs
@@ -35,33 +35,81 @@ add finalizers.
 module Internal.Finalizer (Cell, get, newCell, addFinalizer) where
 
 import Control.Concurrent.MVar (MVar, mkWeakMVar, newEmptyMVar)
-import Control.Concurrent.STM  (STM, TVar, atomically, modifyTVar', newTVar)
+import Control.Concurrent.STM
+    ( STM
+    , TVar
+    , atomically
+    , modifyTVar'
+    , newTVar
+    , readTVar
+    , readTVarIO
+    , retry
+    , writeTVar
+    )
+import Control.Monad           (when)
+import GHC.Conc                (unsafeIOToSTM)
 
 -- | A cell, containing a value and possibly finalizers.
-data Cell a = Cell
-    { value      :: a
+newtype Cell a = Cell (TVar (CellState a))
+    deriving(Eq)
+
+data CellState a = CellState
+    { value       :: a
     -- ^ The value wrapped by the cell.
-    , finalizers :: TVar [MVar ()]
+    , finalizers  :: TVar [MVar ()]
     -- ^ Experimentally, TVars appear not to be safe for finalizers, so
     -- instead we create MVars for the finalizers, and store them this
     -- list so that we maintain a reference to them.
+
+    , isFinalized :: TVar Bool
+    -- ^ Note [Finalizer race]
     }
     deriving(Eq)
 
 -- | Get the value from a cell
-get :: Cell a -> a
-get = value
+get :: Cell a -> STM a
+get (Cell state) = do
+    CellState{value, isFinalized} <- readTVar state
+    finalized <- readTVar isFinalized
+    when finalized $ do
+        -- Note [Finalizer race]
+        unsafeIOToSTM $ putStrLn "BUG in haskell-capnp: finalizer ran before Cell was unreachable!"
+        retry
+    pure value
 
 -- Create  a new cell, initially with no finalizers.
 newCell :: a -> STM (Cell a)
 newCell value = do
+    isFinalized <- newTVar False
     finalizers <- newTVar []
-    pure Cell { value, finalizers }
+    Cell <$> newTVar CellState { value, finalizers, isFinalized }
 
 -- Add a new finalizer to the cell. Cells may have many finalizers
 -- attached.
-addFinalizer :: Cell a -> IO () -> IO ()
-addFinalizer Cell{finalizers} fin = do
+addFinalizer :: Cell a -> STM () -> IO ()
+addFinalizer (Cell state) fin = do
+    CellState {finalizers, isFinalized} <- readTVarIO state
     mvar <- newEmptyMVar
-    _ <- mkWeakMVar mvar fin
+    _ <- mkWeakMVar mvar $ atomically $ do
+        fin
+        writeTVar isFinalized True
     atomically $ modifyTVar' finalizers (mvar:)
+
+-- Note [Finalizer race]
+--
+-- Per issue #74, in a previous implementation it was possible for the cell to
+-- be collected before a transaction that used it completes, and for the finalizer
+-- to run to completion also before the transaction completes. To avoid this,
+-- we need to make sure that the finalizer and any transaction that uses the cell
+-- conflict, such that the finalizer always comes in a *later* transaction.
+--
+-- To achieve this we store a shared isFinalized TVar, and write to it from the
+-- finalizers. 'get' reads it and verifies that it has not been set; if it has
+-- it retries.
+--
+-- Subtly, this actually prevents the finalizer from running, because the
+-- possibility of a retry means we need to keep holding the reference so we
+-- can access the cell in a subsequent attempt -- so the retry should never actually
+-- occur, but still needs to be there for correctness. We add a print statement
+-- to the branch, so that if there is a bug where this actually *can* happen,
+-- we get some indicator of this, rather than just deadlocking.


### PR DESCRIPTION
Per my [comment](https://github.com/zenhack/haskell-capnp/pull/75#issuecomment-706730862), this tries to ensure that the finalizers on a cell do not run until after any transaction accessing that cell completes, which should fix #74.

I decided based on the change in strategy we really should keep the api as `get` rather than `with`, but make `get` run in STM; `with` would be confusing in this case because the lambda doesn't really correlate with the actual lifetime involved.

@p4l1ly, could you test this?

Note that the master branch has a few experimental changes that you may want to skip until I've had time to test them more carefully; I've also cherry-picked this onto a branch called `v0.6.0.x`, which I'll turn into a new release if this works; you may want to test that branch instead.