### PR TITLE
Fix call to `newSegment` violating `maxSegmentSize` invariant, and minor improvements

### DIFF
--- a/lib/Capnp/Errors.hs
+++ b/lib/Capnp/Errors.hs
@@ -38,7 +38,7 @@ data Error
     -- | A 'SizeError' indicates that an operation would have resulted in
     -- a message that violated the library's limit on either segment size
     -- or number of segments.
-    | SizeError
+    | SizeError String
     -- | A 'SchemaViolationError' indicates that part of the message does
     -- not match the schema. The argument to the data construtor is a
     -- human-readable error message.

--- a/lib/Capnp/Message.hs
+++ b/lib/Capnp/Message.hs
@@ -453,7 +453,7 @@ write MutSegment{vec} (WordCount i) val = do
 -- number and the segment itself. Amortized O(1).
 newSegment :: WriteCtx m s => MutMsg s -> Int -> m (Int, Segment (MutMsg s))
 newSegment msg@MutMsg{mutSegs} sizeHint = do
-    when (sizeHint > maxSegmentSize) $ throwM E.SizeError
+    when (sizeHint > maxSegmentSize) $ throwM $ E.SizeError $ "newSegment: sizeHint > maxSegmentSize (" ++ show sizeHint ++ " > " ++ show maxSegmentSize ++ ")"
     -- the next segment number will be equal to the *current* number of
     -- segments:
     segIndex <- numSegs msg
@@ -496,7 +496,7 @@ allocInSeg msg segIndex size = do
 alloc :: WriteCtx m s => MutMsg s -> WordCount -> m (WordPtr (MutMsg s))
 alloc msg size@(WordCount sizeInt) = do
     when (sizeInt > maxSegmentSize) $
-        throwM E.SizeError
+        throwM $ E.SizeError $ "alloc: sizeInt > maxSegmentSize (" ++ show sizeInt ++ " > " ++ show maxSegmentSize ++ ")"
     segIndex <- pred <$> numSegs msg
     existing <- allocInSeg msg segIndex size
     case existing of

--- a/lib/Capnp/Message.hs
+++ b/lib/Capnp/Message.hs
@@ -449,7 +449,7 @@ write MutSegment{vec} (WordCount i) val = do
     SMV.write vec i (toLE64 val)
 
 -- | @'newSegment' msg sizeHint@ allocates a new, initially empty segment in
--- @msg@ with a capacity of @sizeHint@. It returns the a pair of the segment
+-- @msg@ with a capacity of @sizeHint@ words. It returns the a pair of the segment
 -- number and the segment itself. Amortized O(1).
 newSegment :: WriteCtx m s => MutMsg s -> Int -> m (Int, Segment (MutMsg s))
 newSegment msg@MutMsg{mutSegs} sizeHint = do

--- a/lib/Capnp/Message.hs
+++ b/lib/Capnp/Message.hs
@@ -36,6 +36,10 @@ module Capnp.Message (
     , ConstMsg
     , empty
     , singleSegment
+    , constSegs
+    , constMsgFromSegments
+    , constSegToVec
+    , constSegFromVec
 
     -- * Reading data from messages
     , getSegment
@@ -538,6 +542,14 @@ singleSegment seg = ConstMsg
     , constCaps = V.empty
     }
 
+constMsgFromSegments :: V.Vector (Segment ConstMsg) -> ConstMsg
+constMsgFromSegments segments = ConstMsg
+    { constSegs = segments
+    , constCaps = V.empty
+    }
+
+constSegFromVec :: SV.Vector Word64 -> Segment ConstMsg
+constSegFromVec = ConstSegment
 
 instance Thaw (Segment ConstMsg) where
     type Mutable s (Segment ConstMsg) = Segment (MutMsg s)

--- a/lib/Capnp/Message.hs
+++ b/lib/Capnp/Message.hs
@@ -504,9 +504,10 @@ alloc msg size@(WordCount sizeInt) = do
         Nothing -> do
             -- Not enough space in the current segment; allocate a new one.
             -- the new segment's size should match the total size of existing segments
+            -- but `maxSegmentSize` bounds how large it can get.
             WordCount totalAllocation <- sum <$>
                 traverse (getSegment msg >=> numWords) [0..segIndex]
-            ( newSegIndex, _ ) <- newSegment msg (max totalAllocation sizeInt)
+            ( newSegIndex, _ ) <- newSegment msg (min (max totalAllocation sizeInt) maxSegmentSize)
             -- This is guaranteed to succeed, since we just made a segment with
             -- at least size available space:
             fromJust <$> allocInSeg msg newSegIndex size

--- a/lib/Internal/AppendVec.hs
+++ b/lib/Internal/AppendVec.hs
@@ -84,7 +84,7 @@ grow :: (MonadThrow m, PrimMonad m, s ~ PrimState m, GMV.MVector v a)
     => AppendVec v s a -> Int -> Int -> m (AppendVec v s a)
 grow vec@AppendVec{mutVec,mutVecLen} amount maxSize = do
     when (maxSize - amount < mutVecLen) $
-        throwM SizeError
+        throwM $ SizeError $ "grow: maxSize - amount < mutVecLen (" ++ show maxSize ++ " - " ++ show amount ++ " < " ++ show mutVecLen ++ ")"
     mutVec <-
         if canGrowWithoutCopy vec amount then
             -- we have enough un-allocated space already; leave the vector


### PR DESCRIPTION
Hi, @chpatrick and me made some minor fixes and also this commit:

`Fix call to `newSegment` violating `maxSegmentSize` invariant.`

which I believe to fix a logic bug.

If you like I can split the PR (or you can cherry-pick what you find good), but these are the changes we currently need for our usage of haskell-capnp. 