### PR TITLE
Add membrane support.

### DIFF
--- a/capnp.cabal
+++ b/capnp.cabal
@@ -101,6 +101,7 @@ library
       , Capnp.Classes
       , Capnp.Constraints
       , Capnp.Rpc.Common
+      , Capnp.Rpc.Membrane
       , Capnp.Rpc.Server
       , Capnp.New.Rpc.Server
       , Capnp.Convert

--- a/capnp.cabal
+++ b/capnp.cabal
@@ -103,6 +103,7 @@ library
       , Capnp.Rpc.Common
       , Capnp.Rpc.Membrane
       , Capnp.Rpc.Server
+      , Capnp.Rpc.Revoke
       , Capnp.New.Rpc.Server
       , Capnp.Convert
       , Capnp.Errors

--- a/lib/Capnp/Rpc/Membrane.hs
+++ b/lib/Capnp/Rpc/Membrane.hs
@@ -1,0 +1,91 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
+module Capnp.Rpc.Membrane
+  ( Action (..),
+    Direction (..),
+    Call (..),
+    Policy,
+    enclose,
+    exclude,
+  )
+where
+
+import qualified Capnp.Rpc.Common as Rpc
+import qualified Capnp.Rpc.Server as Server
+import qualified Capnp.Rpc.Untyped as URpc
+import Control.Concurrent.STM
+import Control.Monad.STM.Class
+import Data.Typeable (Typeable, cast)
+import Data.Word
+import Supervisors (Supervisor)
+
+data Action
+  = Redirect URpc.Client
+  | Forward
+  deriving (Eq)
+
+data Direction = In | Out
+  deriving (Show, Read, Eq)
+
+data Call = Call
+  { direction :: Direction,
+    interfaceId :: Word64,
+    methodId :: Word16,
+    target :: URpc.Client
+  }
+
+type Policy = Call -> Action
+
+enclose :: MonadSTM m => Supervisor -> Rpc.Client a -> Policy -> m (Rpc.Client a)
+enclose = newMembrane In
+
+exclude :: MonadSTM m => Supervisor -> Rpc.Client a -> Policy -> m (Rpc.Client a)
+exclude = newMembrane Out
+
+newMembrane :: MonadSTM m => Direction -> Supervisor -> Rpc.Client a -> Policy -> m (Rpc.Client a)
+newMembrane dir sup (Rpc.Client toWrap) policy = liftSTM $ do
+  identity <- newTVar ()
+  let mem = Membrane {policy, identity}
+  Rpc.Client <$> pass dir sup mem toWrap
+
+data MembraneWrapped = MembraneWrapped
+  { client :: URpc.Client,
+    membrane :: Membrane,
+    side :: Direction
+  }
+  deriving (Typeable)
+
+data Membrane = Membrane
+  { policy :: Policy,
+    -- | an object with identity, for comparison purposes:
+    identity :: TVar ()
+  }
+
+instance Eq Membrane where
+  x == y = identity x == identity y
+
+pass :: MonadSTM m => Direction -> Supervisor -> Membrane -> URpc.Client -> m URpc.Client
+pass dir sup mem inClient = liftSTM $
+  case URpc.unwrapServer inClient :: Maybe MembraneWrapped of
+    Just mw | onSide dir mw mem -> pure $ client mw
+    _ ->
+      URpc.export
+        sup
+        Server.ServerOps
+          { Server.handleCast =
+              cast $
+                MembraneWrapped
+                  { client = inClient,
+                    membrane = mem,
+                    side = dir
+                  },
+            -- Once we're gc'd, the downstream client will be as well
+            -- and then the relevant shutdown logic will still be called.
+            -- This introduces latency unfortuantely, but nothing is broken.
+            Server.handleStop = pure (),
+            Server.handleCall = \interfaceId methodId -> error "TODO"
+          }
+
+onSide :: Direction -> MembraneWrapped -> Membrane -> Bool
+onSide dir mw mem =
+  membrane mw == mem && dir == side mw

--- a/lib/Capnp/Rpc/Membrane.hs
+++ b/lib/Capnp/Rpc/Membrane.hs
@@ -2,13 +2,22 @@
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE RecordWildCards #-}
 
+-- | Module: Capnp.Rpc.Membrane
+-- Descritpion: Helpers for working with membranes.
+--
+-- Membranes are common in object-capability design. Think of it like a
+-- proxy on steroids: a membrane inserts itself in front of another capability,
+-- and can intercept and modify method calls. Unlike a simple proxy though,
+-- the membrane will also be applied to any objects returned by method calls,
+-- or passed in arguments, transitively, so it can sit in front of entire
+-- object graphs.
 module Capnp.Rpc.Membrane
-  ( Action (..),
+  ( enclose,
+    exclude,
+    Policy,
+    Action (..),
     Direction (..),
     Call (..),
-    Policy,
-    enclose,
-    exclude,
   )
 where
 
@@ -25,10 +34,19 @@ import Data.Typeable (Typeable, cast)
 import Data.Word
 import Supervisors (Supervisor)
 
+-- | An action indicates what to do with an incoming method call.
 data Action
-  = Handle Server.UntypedMethodHandler
-  | Forward
+  = -- | Handle the method using the provided method handler, instead of
+    -- letting it through the membrane. Arguments and return values will not
+    -- be wrapped/unwraped, so be careful when delegating to objects inside
+    -- the membrane.
+    Handle Server.UntypedMethodHandler
+  | -- | Forward the method call on to its original destination, wrapping
+    -- and unwrapping arguments & return values as normal.
+    Forward
 
+-- | A Direction indicates which direction a method call is traveling:
+-- into or out of the membrane.
 data Direction = In | Out
   deriving (Show, Read, Eq)
 
@@ -36,20 +54,36 @@ flipDir :: Direction -> Direction
 flipDir In = Out
 flipDir Out = In
 
+-- | Alias for direction; somtimes it is convienent to think about capabilities
+-- from the standpoint of which side they is _on_, rather than where it is going
+-- as with methods.
 type Side = Direction
 
+-- | A 'Call' represents a method call that is crossing the membrane.
 data Call = Call
-  { direction :: Direction,
+  { -- | Which direction is the call going? if this is 'In', the call was made
+    -- by something outside the membrane to something inside it. If it is 'Out',
+    -- something inside the membrane is making a call to something outside the
+    -- membrane.
+    direction :: Direction,
+    -- | The interface id of the method being called.
     interfaceId :: Word64,
+    -- | The ordinal of the method being called.
     methodId :: Word16,
+    -- | The target of the method call.
     target :: URpc.Client
   }
 
+-- | A 'Policy' decides what to do when a call crosses the membrane.
 type Policy = Call -> STM Action
 
+-- | @'enclose' sup cap policy@ wraps @cap@ in a membrane whose behavior is
+-- goverend by @policy@.
 enclose :: (URpc.IsClient c, MonadSTM m) => Supervisor -> c -> Policy -> m c
 enclose = newMembrane In
 
+-- | 'exclude' is like 'enclose', except that the capability is treated as
+-- being *outside* of a membrane that wraps the rest of the world.
 exclude :: (URpc.IsClient c, MonadSTM m) => Supervisor -> c -> Policy -> m c
 exclude = newMembrane Out
 

--- a/lib/Capnp/Rpc/Revoke.hs
+++ b/lib/Capnp/Rpc/Revoke.hs
@@ -1,5 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 
+-- | Module: Capnp.Rpc.Revoke
+-- Description: support for revocable capababilities
 module Capnp.Rpc.Revoke
   ( makeRevocable,
   )
@@ -14,6 +16,14 @@ import Control.Concurrent.STM
 import Control.Monad.STM.Class (MonadSTM, liftSTM)
 import Supervisors (Supervisor)
 
+-- | @'makeRevocable' sup cap@ returns a pair @(wrappedCap, revoke)@, such that
+-- @wrappedCap@ is @cap@ wrapped by a membrane which forwards all method invocations
+-- along until @revoke@ is executed, after which all methods that cross the membrane
+-- (in either direction) will return errors.
+--
+-- Note that, as per usual with membranes, the membrane will wrap any objects returned
+-- by method calls. So revoke cuts off access to the entire object graph reached through
+-- @cap@.
 makeRevocable :: (MonadSTM m, IsClient c) => Supervisor -> c -> m (c, STM ())
 makeRevocable sup client = liftSTM $ do
   isRevoked <- newTVar False

--- a/lib/Capnp/Rpc/Revoke.hs
+++ b/lib/Capnp/Rpc/Revoke.hs
@@ -1,0 +1,32 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Capnp.Rpc.Revoke
+  ( makeRevocable,
+  )
+where
+
+import Capnp.Rpc.Errors (eFailed)
+import qualified Capnp.Rpc.Membrane as Membrane
+import Capnp.Rpc.Promise (breakPromise)
+import qualified Capnp.Rpc.Server as Server
+import Capnp.Rpc.Untyped (IsClient)
+import Control.Concurrent.STM
+import Control.Monad.STM.Class (MonadSTM, liftSTM)
+import Supervisors (Supervisor)
+
+makeRevocable :: (MonadSTM m, IsClient c) => Supervisor -> c -> m (c, STM ())
+makeRevocable sup client = liftSTM $ do
+  isRevoked <- newTVar False
+  wrappedClient <- Membrane.enclose sup client (revokerPolicy isRevoked)
+  pure (wrappedClient, writeTVar isRevoked True)
+
+revokerPolicy :: TVar Bool -> Membrane.Policy
+revokerPolicy isRevoked _call = do
+  revoked <- readTVar isRevoked
+  pure $
+    if revoked
+      then Membrane.Handle revokedHandler
+      else Membrane.Forward
+
+revokedHandler :: Server.UntypedMethodHandler
+revokedHandler = Server.untypedHandler $ \_ response -> breakPromise response (eFailed "revoked")

--- a/lib/Capnp/Rpc/Server.hs
+++ b/lib/Capnp/Rpc/Server.hs
@@ -24,6 +24,7 @@ module Capnp.Rpc.Server
     -- * Handling methods
     MethodHandler,
     UntypedMethodHandler,
+    handleUntypedMethod,
 
     -- ** Working with untyped data
     untypedHandler,
@@ -64,6 +65,9 @@ newtype MethodHandler p r = MethodHandler
 -- | Alias for a 'MethodHandler' whose parameter and return types are
 -- untyped pointers.
 type UntypedMethodHandler = MethodHandler (Maybe (Ptr 'Const)) (Maybe (Ptr 'Const))
+
+handleUntypedMethod :: UntypedMethodHandler -> Maybe (Ptr 'Const) -> Fulfiller (Maybe (Ptr 'Const)) -> IO ()
+handleUntypedMethod = handleMethod
 
 -- | Convert a 'MethodHandler' for any parameter and return types into
 -- one that deals with untyped pointers.


### PR DESCRIPTION
This patch adds support/helpers for membranes, a common object-capability design pattern; see docs on Capnp.Rpc.Membrane. It also adds an implementation of a simple revoker, which is useful in its own right but was aslo helpful in validating the API.

I plan on building some helpers for persistence on top of this.